### PR TITLE
feat(playwright-devcontainer): add playwright devconainer image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Setup project
         uses: ./.github/actions/setup
         with:

--- a/devcontainer-images/playwright-devcontainer/.devcontainer/Dockerfile
+++ b/devcontainer-images/playwright-devcontainer/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/playwright:v1.48.1-noble

--- a/devcontainer-images/playwright-devcontainer/.devcontainer/devcontainer-lock.json
+++ b/devcontainer-images/playwright-devcontainer/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,44 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-extra/features/nx-npm:1": {
+      "version": "1.0.10",
+      "resolved": "ghcr.io/devcontainers-extra/features/nx-npm@sha256:e4da001ff751591343f38a928f77501898b9ef68fb2bba1f5617cb8cb2558949",
+      "integrity": "sha256:e4da001ff751591343f38a928f77501898b9ef68fb2bba1f5617cb8cb2558949"
+    },
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.2",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:5b1c376d30719a4dead8fb2f272ee496cfb506f2f92b7acf9e1c24cb5399ba7d",
+      "integrity": "sha256:5b1c376d30719a4dead8fb2f272ee496cfb506f2f92b7acf9e1c24cb5399ba7d"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.12.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:5f3e2005aad161ce3ff7700b2603f11935348c039f9166960efd050d69cd3014",
+      "integrity": "sha256:5f3e2005aad161ce3ff7700b2603f11935348c039f9166960efd050d69cd3014"
+    },
+    "ghcr.io/devcontainers/features/git-lfs:1": {
+      "version": "1.2.3",
+      "resolved": "ghcr.io/devcontainers/features/git-lfs@sha256:7acbf0a99325949b6a2906ebf5aa421dad72b89ab8045031a60e69cb394a16b1",
+      "integrity": "sha256:7acbf0a99325949b6a2906ebf5aa421dad72b89ab8045031a60e69cb394a16b1"
+    },
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.2",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:63c96e8ac33f5630300d8883e2ec3123278de70d318589af596ea1954846014d",
+      "integrity": "sha256:63c96e8ac33f5630300d8883e2ec3123278de70d318589af596ea1954846014d"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.6.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:71590121aaf7b2040f3e1e2dfc4bb9a1389277fd5a88a7199094542b82ce5340",
+      "integrity": "sha256:71590121aaf7b2040f3e1e2dfc4bb9a1389277fd5a88a7199094542b82ce5340"
+    },
+    "ghcr.io/michidk/devcontainers-features/bun:1": {
+      "version": "1.0.1",
+      "resolved": "ghcr.io/michidk/devcontainers-features/bun@sha256:568cc553062d184932ba993db954d4ace2bda3907d129477ce174777ac686dbd",
+      "integrity": "sha256:568cc553062d184932ba993db954d4ace2bda3907d129477ce174777ac686dbd"
+    },
+    "ghcr.io/trunk-io/devcontainer-feature/trunk:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/trunk-io/devcontainer-feature/trunk@sha256:8d913c1753a4e188400da05c64c958c78caedb2c92b984988891c443c3cc1e4d",
+      "integrity": "sha256:8d913c1753a4e188400da05c64c958c78caedb2c92b984988891c443c3cc1e4d"
+    }
+  }
+}

--- a/devcontainer-images/playwright-devcontainer/.devcontainer/devcontainer.json
+++ b/devcontainer-images/playwright-devcontainer/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "image": "",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": "true",
+      "installOhMyZsh": "true",
+      "configureZshAsDefaultShell": true,
+      "installOhMyZshConfig": true,
+      "username": "vscode",
+      "userUid": "1000",
+      "userGid": "1000",
+      "upgradePackages": "true"
+    },
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/git-lfs:1": {
+      "autoPull": true
+    },
+    "ghcr.io/trunk-io/devcontainer-feature/trunk:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers-extra/features/nx-npm:1": {},
+    "ghcr.io/michidk/devcontainers-features/bun:1": {}
+  },
+  "remoteUser": "ebizer"
+}

--- a/devcontainer-images/playwright-devcontainer/project.json
+++ b/devcontainer-images/playwright-devcontainer/project.json
@@ -1,0 +1,50 @@
+{
+  "name": "playwright-devcontainer",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "devcontainer-images/playwright-devcontainer",
+  "projectType": "application",
+  "metadata": {
+    "org.opencontainers.image.description": "Playwright devcontainer image for ebizbase"
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "dependsOn": [],
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "devcontainer build --experimental-lockfile --workspace-folder universal-devcontainer/devcontainer --image-name=universal-devcontainer:edge"
+        ],
+        "parallel": false
+      }
+    },
+    "test": {
+      "dependsOn": ["devcontainer:build"],
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "docker run --rm devcontainer:edge zsh --version",
+          "docker run --rm devcontainer:edge git --version",
+          "docker run --rm devcontainer:edge git lfs --version",
+          "docker run --rm devcontainer:edge trunk --version",
+          "docker run --rm devcontainer:edge node --version",
+          "docker run --rm devcontainer:edge npm --version",
+          "docker run --rm devcontainer:edge pnpm --version",
+          "docker run --rm devcontainer:edge yarn --version",
+          "docker run --rm devcontainer:edge bun --version",
+          "docker run --rm devcontainer:edge docker --version",
+          "docker run --rm devcontainer:edge docker buildx version",
+          "docker run --rm devcontainer:edge docker compose version"
+        ],
+        "parallel": false
+      }
+    },
+    "publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "node ./scripts/publish.js devcontainer-images/universal-devcontainer ebizbase/universal-devcontainer:{version} true",
+        "parallel": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a new Playwright devcontainer configuration with several enhancements and features. The most important changes include updating the Dockerfile, adding a devcontainer lock file, defining the devcontainer configuration, and specifying project metadata and build commands.

### Devcontainer configuration:

* [`devcontainer-images/playwright-devcontainer/.devcontainer/Dockerfile`](diffhunk://#diff-4e8a087a250345aa1993ec374f1a94461807fa25a22fe75d02eedd86ce37aa9bR1): Updated to use the Playwright image version `v1.48.1-noble`.
* [`devcontainer-images/playwright-devcontainer/.devcontainer/devcontainer-lock.json`](diffhunk://#diff-34e5fbd33be08e6b336da9c466115bb40cf6f77a5b825b7e2fbc7abd008f49b5R1-R44): Added a lock file specifying various features and their versions, ensuring consistent environment setup.
* [`devcontainer-images/playwright-devcontainer/.devcontainer/devcontainer.json`](diffhunk://#diff-e9d98c8af205f498b5e21295e0d156e8877c9754117a3dde83b1d81eb364640fR1-R25): Defined the devcontainer configuration, including features like Zsh, Git, Git LFS, Trunk, Docker-in-Docker, Node, NX NPM, and Bun, along with user settings.

### Project metadata and build commands:

* [`devcontainer-images/playwright-devcontainer/project.json`](diffhunk://#diff-f9f163608e2ea92b733b1e239c700f6084b97bb4247f9aa3d45b2276553c191cR1-R50): Added project metadata and defined build, test, and publish targets with specific commands to manage the devcontainer image.