### PR TITLE
feat(node-distroless): add node-distroless image combines google dist…

### DIFF
--- a/images/node-distroless/Dockerfile
+++ b/images/node-distroless/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:22-alpine AS init
+RUN apk add --no-cache dumb-init
+
+FROM gcr.io/distroless/nodejs22:latest AS runtime
+COPY --from=init /usr/bin/dumb-init /usr/bin/dumb-init
+ENTRYPOINT [ "/usr/bin/dumb-init", "--", "/nodejs/bin/node" ]

--- a/images/node-distroless/README.md
+++ b/images/node-distroless/README.md
@@ -1,0 +1,16 @@
+# node-distroless
+
+This image combines the compactness and security of distroless with the convenience of dumb-init for process management, making Node.js applications run more stably in a container environment.
+
+> This image is maintained with node latest LTS version
+
+## Usage
+
+The simple usage example
+
+```dockerfile
+FROM ghcr.io/ebizbase/node-distroless
+WORKDIR /usr/src/app
+COPY . .
+CMD [ "index.js" ]
+```

--- a/images/node-distroless/project.json
+++ b/images/node-distroless/project.json
@@ -1,0 +1,32 @@
+{
+  "name": "node-distroless",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "metadata": {
+    "version": "0.0.0"
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@ebizbase/nx-docker:build",
+      "options": {
+        "tags": ["node-distroless:edge"],
+        "outputs": ["type=docker"]
+      }
+    },
+    "test": {
+      "dependsOn": ["build"],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "docker run --rm node-distroless:edge -e 'console.log(process.version)'"
+      }
+    },
+    "publish": {
+      "executor": "@ebizbase/nx-docker:build",
+      "options": {
+        "tags": ["ghcr.io/ebizbase/node-distroless"],
+        "outputs": ["type=image"]
+      }
+    }
+  }
+}

--- a/release-config.json
+++ b/release-config.json
@@ -103,6 +103,16 @@
           "jsonpath": "$.metadata.version"
         }
       ]
+    },
+    "images/node-distroless": {
+      "package-name": "node-distroless",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "project.json",
+          "jsonpath": "$.metadata.version"
+        }
+      ]
     }
   }
 }

--- a/release-manifest.json
+++ b/release-manifest.json
@@ -10,5 +10,6 @@
   "devcontainer-images/node-devcontainer": "1.0.0",
   "devcontainer-images/node-dind-devcontainer": "1.0.0",
   "devcontainer-images/node-dind-playwright-devcontainer": "1.0.0",
-  "devcontainer-images/node-playwright-devcontainer": "1.0.0"
+  "devcontainer-images/node-playwright-devcontainer": "1.0.0",
+  "images/node-distroless": "0.0.0"
 }


### PR DESCRIPTION
This pull request introduces a new `node-distroless` Docker image, which combines the compactness and security of distroless with the convenience of dumb-init for process management. The changes include creating the Dockerfile, adding a test Dockerfile, updating documentation, and configuring project and release files.

Key changes include:

### Dockerfile and Test Dockerfile:

* [`images/node-distroless/Dockerfile`](diffhunk://#diff-7eff4e33f3817cde799c7a4c8ec8293caba277249e0d0aa14008857ae8263245R1-R6): Created a Dockerfile that uses `node:20-alpine` for initialization and `gcr.io/distroless/nodejs22` for runtime, adding dumb-init for process management.
* [`images/node-distroless/Dockerfile.test`](diffhunk://#diff-480d14a490eb50491f195c732c3415c674d6873db39c507840138ee0d15af572R1-R7): Added a test Dockerfile to build and test the `node-distroless` image.

### Documentation:

* [`images/node-distroless/README.md`](diffhunk://#diff-64b8788e5e5765ffcf5a8193cf7c2071a86b47a6ccc8cecd275dff72dc0b4d82R1-R16): Added a README file to explain the purpose and usage of the `node-distroless` image.

### Project Configuration:

* [`images/node-distroless/project.json`](diffhunk://#diff-c48558ad92528e1d7ddb3cf3e1a1cfa2af9bd019c7f2f6993f82807fc99f0bcaR1-R41): Added project configuration for building, testing, and publishing the `node-distroless` image using Nx.

### Release Configuration:

* `release-config.json` and `release-manifest.json`: Updated release configuration files to include the `node-distroless` image with its versioning information. [[1]](diffhunk://#diff-37ae28c358e756a97fdaadb183b140b71ce637c4f3c8056e3315238bf3c77f0eR106-R115) [[2]](diffhunk://#diff-98840968c9d0821f3041fe1c2643b2a0c0580106c4addf8a30864e07c9232c5eL13-R14)